### PR TITLE
New feed URL

### DIFF
--- a/config/config.ini
+++ b/config/config.ini
@@ -789,7 +789,7 @@ name = Marc Richter
 [http://www.malemburg.com/rss]
 name = Marc-André Lemburg
 
-[http://www.grulic.org.ar/~mdione/glob/tags/python/index.atom]
+[http://www.grulic.org.ar/~mdione/glob/categories/python.xml]
 name = Marcos Dione
 
 [http://mg.pov.lt/blog/index.xml]


### PR DESCRIPTION
I switched site generators and its not 100% like the previous one.

# EDIT FEED
-------------------------------------------------------------------------------

I want to change my current feed url from  [http://www.grulic.org.ar/~mdione/glob/tags/python/index.atom to  http://www.grulic.org.ar/~mdione/glob/categories/python.xml

## I checked the following required validations: (mark all 5 with [x])

1. [x] My feed is valid, I checked using https://validator.w3.org/feed/check.cgi?url=http://www.grulic.org.ar/~mdione/glob/categories/python.xml and it is valid!
2. [x] My feed is a **Python Specific** feed, e.g: I am proposing the filtered tag or categorized feed url
3. [x] I only post content to this feed which is related to the Python language and its components and libraries. Or content that I consider interesting for the Python community.
4. [x] I am aware that once my feed is added it can take a few hours to start being fetched (according to the server update cycle)
5. [x] My feed contains only content in English language.
